### PR TITLE
include homepage and repo info

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = "A Manim Plugin that renders LaTeX for Mobjects like Tex and MathT
 license = "MIT"
 authors = ["The Manim Community Developers"]
 readme = "README.md"
+homepage = "https://github.com/ManimCommunity/manim-onlinetex"
+repository = "https://github.com/ManimCommunity/manim-onlinetex"
 classifiers= [
     "Development Status :: 4 - Beta",
     "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
pypi has no project links in sidebar description
 - https://pypi.org/project/manim-onlinetex/

homepage link on the plugin site just links to itself instead of the plugin
 - https://plugins.manim.community/